### PR TITLE
Fix typo leftover in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ deploy:
 		-t webapp .
 
 frontend:
-	cargo web start $(FRONTENT_ARGS) --auto-reload --host 0.0.0.0
+	cargo web start $(FRONTEND_ARGS) --auto-reload --host 0.0.0.0
 
 run: startdb
 	docker run --rm \


### PR DESCRIPTION
Previous commit 67beb65 have have yet change all the `FRONTENT` to `FRONTEND` and it breaks `make frontend`.