### PR TITLE
Fixed cookies with = signs

### DIFF
--- a/frontend/src/service/cookie.rs
+++ b/frontend/src/service/cookie.rs
@@ -30,7 +30,7 @@ impl CookieService {
         cookies
             .iter()
             .filter_map(|x| {
-                let name_value: Vec<_> = x.split('=').collect();
+                let name_value: Vec<_> = x.splitn(2, '=').collect();
                 match name_value.get(0) {
                     None => None,
                     Some(c) => {


### PR DESCRIPTION
Cookies couldn't contain equal signs. For example, base64 encoded cookies would lose the end and fail to decode.