### PR TITLE
Fix: Crucial command on Readme to deploy correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This installs build requirements, rust and wasm-pack, on Ubuntu or Debian.
 > sudo apt-get install -y pkg-config libssl-dev npm sudo wget
 > wget https://sh.rustup.rs -O rustup-init
 > sudo sh rustup-init -y
-> sudo cargo install wasm-pack
+> cargo install wasm-pack
 > sudo npm install -g rollup
 ```
 


### PR DESCRIPTION
Today at Engineer university break, colleagues and I tried to follow the guide, but without success I determine to correct a command for a more comprehensive way, to let people to began a plug and play experience with this amazing and beautiful project, the thing is, we where not able to execute a command correctly with this guide, and we modified for a more comprehensive step, to allow devs to plug and play directly, today and now webapp.js!


This command:
> sudo sh rustup-init -y
> sudo cargo install wasm-pack
> sudo npm install -g rollup

Causes this error:

![webapp.rs-miguelgargallo-contribution-rust-dev](https://user-images.githubusercontent.com/5947268/194014615-2122b0d1-adc4-40de-9143-9e566580c9a8.png)

< sudo: cargo: command not found

So to solve this:

into:
> sudo sh rustup-init -y
> cargo install wasm-pack
> sudo npm install -g rollup

